### PR TITLE
Support custom definitions in build.sbt

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,26 @@ class ATest extends munit.FunSuite {
 }
 ```
 
+custom definitions
+----------------
+
+You can add custom definitions in your build.sbt:
+
+```scala
+// Add a custom definition for early access features
+ThisBuild / ifDefDeclarations += "eap"
+```
+
+Then use them in your code:
+
+```scala
+// This method will only be available when "eap" is defined
+@ifdef("eap")
+def earlyAccessFeature(): Unit = {
+  // Implementation of early access feature
+}
+```
+
 license
 -------
 ifdef is released under Apache License Version 2.0.

--- a/plugin/src/main/scala/IfDefPlugin.scala
+++ b/plugin/src/main/scala/IfDefPlugin.scala
@@ -33,10 +33,11 @@ object IfDefPlugin extends AutoPlugin {
   lazy val configurationSettings: Seq[Def.Setting[?]] = List(
     ifDefDeclarations := {
       val sbv = scalaBinaryVersion.value
-      List(
+      val defaults = List(
         configuration.value.name,
         s"scalaBinaryVersion:$sbv",
       )
+      defaults ++ (ThisBuild / ifDefDeclarations).?.value.getOrElse(Nil)
     },
     scalacOptions := {
       val orig = scalacOptions.value

--- a/plugin/src/sbt-test/sbt-ifdef/simple/A.scala
+++ b/plugin/src/sbt-test/sbt-ifdef/simple/A.scala
@@ -10,6 +10,9 @@ class A {
 
   @ifdef("test")
   def bar: Int = 2
+  
+  @ifdef("eap")
+  def earlyAccess: Boolean = true
 }
 
 @ifdef("test")
@@ -23,6 +26,12 @@ class ATest extends munit.FunSuite {
   test("bar") {
     val actual = new A().bar
     val expected = 2
+    assertEquals(actual, expected)
+  }
+  
+  test("earlyAccess") {
+    val actual = new A().earlyAccess
+    val expected = true
     assertEquals(actual, expected)
   }
 }

--- a/plugin/src/sbt-test/sbt-ifdef/simple/build.sbt
+++ b/plugin/src/sbt-test/sbt-ifdef/simple/build.sbt
@@ -3,3 +3,5 @@ val scala213 = "2.13.12"
 ThisBuild / scalaVersion := scala212
 ThisBuild / crossScalaVersions := List(scala213, scala212)
 libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
+
+ThisBuild / ifDefDeclarations += "eap"


### PR DESCRIPTION
Hello,

First, thank you for the awesome plugin!
Second, sorry for the drive-by PR, but I needed to use this today and didn't find a way to create a custom definition.

I modified the plugin a bit to allow defining a custom definition in `ifDefDeclarations` and using it from the code, e.g.:

`ThisBuild / ifDefDeclarations += "eap"`

allowing me to use `@ifdef/ifndef("eap")`

If acceptable, I would love if you could merge this so I could use it in my project (an IntelliJ plugin)

Thanks!